### PR TITLE
fix(web): Include URLParams on updateQuery

### DIFF
--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -179,7 +179,7 @@ class ReactiveComponent extends Component {
 				this.props.updateQuery({
 					componentId: this.props.componentId,
 					query: null,
-					URLParams: this.props.URLParams
+					URLParams: this.props.URLParams,
 				});
 			}
 		});
@@ -219,7 +219,7 @@ class ReactiveComponent extends Component {
 			this.props.updateQuery({
 				componentId: this.props.componentId,
 				query: query || null,
-				URLParams: this.props.URLParams
+				URLParams: this.props.URLParams,
 			});
 		}
 	}

--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -179,6 +179,7 @@ class ReactiveComponent extends Component {
 				this.props.updateQuery({
 					componentId: this.props.componentId,
 					query: null,
+					URLParams: this.props.URLParams
 				});
 			}
 		});
@@ -218,6 +219,7 @@ class ReactiveComponent extends Component {
 			this.props.updateQuery({
 				componentId: this.props.componentId,
 				query: query || null,
+				URLParams: this.props.URLParams
 			});
 		}
 	}


### PR DESCRIPTION
Fixes #1460

Issue: When using ReactiveComponent with URLParams, clearing the selectedValue by clicking its filter in SelectedFilters does not remove the URL param for the component from the query string. This is an issue because if someone refreshes, that filter is still there, despite removing it.

It appears the issue is that `setQuery` does not pass whether the component uses URLParams so the query string is not updated. In the GIF below, you can see that URLParams for "attachment.title" changes from `true` to `false` in the URLParamsProvider component.

![image](https://user-images.githubusercontent.com/11220250/140410339-c08a546a-8121-464c-9006-50b87defd7d1.png)

This change includes the URLParams prop in relevant updateQuery calls. Making these changes, you can see in the GIF below that the URLParams value for the componentId ("attachment.title") does not change, and the queryString is properly updated.
![image](https://user-images.githubusercontent.com/11220250/140412038-8eb6d94a-0bb7-42a5-8698-f7302f86b116.png)


**Before submitting a pull request,** please make sure the following is done:

- [X ] Describe the proposed changes and how it'll improve the library experience.
- [X] Please make sure that there are no linting errors in the code.
- [X] Add a demo video/gif/screenshot to explain how did you test the fix.
- [X] ~~If it is a global change, try to add any side effects that it could have.~~ (N/A)
- [X] ~~Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).~~ (N/A)
- [X] ~~Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).~~ (N/A)

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
